### PR TITLE
OCI Target input.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,9 @@ inputs:
   PAT:
     description: GitHub Pesonal Access Token
     required: true
+  OCITARGET:
+    description: "OCI target used in the signature verification"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -24,5 +27,5 @@ runs:
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/kubewarden/policy-hub/actions/workflows/update-policy.yml/dispatches \
-          -d '{"ref":"main", "inputs": {"repository": "'${GITHUB_REPOSITORY}'", "tag": "'${TAG}'"}}')
+          -d '{"ref":"main", "inputs": {"repository": "'${GITHUB_REPOSITORY}'", "tag": "'${TAG}'", "oci-target":"${{ inputs.OCITARGET }}"}}')
         (( $HTTP_CODE == 204 ))


### PR DESCRIPTION
In order make policy hub able to verify the policies signatures, it's necessary to define the policy OCI target used to check the signatures.

Related to https://github.com/kubewarden/policy-hub/pull/179